### PR TITLE
ClientConn Unhealthy method:fix typo in name

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -161,9 +161,9 @@ func (p *Pool) Get(ctx context.Context) (*ClientConn, error) {
 	return &wrapper, err
 }
 
-// Unhealhty marks the client conn as unhealthy, so that the connection
+// Unhealthy marks the client conn as unhealthy, so that the connection
 // gets reset when closed
-func (c *ClientConn) Unhealhty() {
+func (c *ClientConn) Unhealthy() {
 	c.unhealthy = true
 }
 


### PR DESCRIPTION
Thanks for this great library! It has definitely helped with grpc connection pooling combined with server side load balancers.

Just wanted to point out a minor typo in a method name, cheers!