### PR TITLE
Add maxLifeDuration option to recycle old connections

### DIFF
--- a/pool_test.go
+++ b/pool_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNew(t *testing.T) {
 	p, err := New(func() (*grpc.ClientConn, error) {
-		return &grpc.ClientConn{}, nil
+		return grpc.Dial("example.com", grpc.WithInsecure())
 	}, 1, 3, 0)
 	if err != nil {
 		t.Errorf("The pool returned an error: %s", err.Error())
@@ -94,7 +94,7 @@ func TestNew(t *testing.T) {
 
 func TestTimeout(t *testing.T) {
 	p, err := New(func() (*grpc.ClientConn, error) {
-		return &grpc.ClientConn{}, nil
+		return grpc.Dial("example.com", grpc.WithInsecure())
 	}, 1, 1, 0)
 	if err != nil {
 		t.Errorf("The pool returned an error: %s", err.Error())
@@ -120,7 +120,7 @@ func TestTimeout(t *testing.T) {
 
 func TestMaxLifeDuration(t *testing.T) {
 	p, err := New(func() (*grpc.ClientConn, error) {
-		return &grpc.ClientConn{}, nil
+		return grpc.Dial("example.com", grpc.WithInsecure())
 	}, 1, 1, 0, 1)
 	if err != nil {
 		t.Errorf("The pool returned an error: %s", err.Error())

--- a/pool_test.go
+++ b/pool_test.go
@@ -117,3 +117,26 @@ func TestTimeout(t *testing.T) {
 		t.Errorf("Expected error \"%s\" but got \"%s\"", ErrTimeout, err2.Error())
 	}
 }
+
+func TestMaxLifeDuration(t *testing.T) {
+	p, err := New(func() (*grpc.ClientConn, error) {
+		return &grpc.ClientConn{}, nil
+	}, 1, 1, 0, 1)
+	if err != nil {
+		t.Errorf("The pool returned an error: %s", err.Error())
+	}
+
+	c, err := p.Get(context.Background())
+	if err != nil {
+		t.Errorf("Get returned an error: %s", err.Error())
+	}
+
+	// The max life of the connection was very low (1ns), so when we close
+	// the connection it should get marked as unhealthy
+	if err := c.Close(); err != nil {
+		t.Errorf("Close returned an error: %s", err.Error())
+	}
+	if !c.unhealthy {
+		t.Errorf("the connection should've been marked as unhealthy")
+	}
+}


### PR DESCRIPTION
Adds a new option to set how long a connection should live, and recycle it once this duration is reached.
I realize the new option isn't introduced in the best way in the `New` function, but this aims to keep older implementations working.