### PR TITLE
Fix prematurely marking the connections unhealthy, when maxLifeDuration is set

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -210,6 +210,8 @@ func (c *ClientConn) Close() error {
 	if c.unhealthy {
 		wrapper.ClientConn.Close()
 		wrapper.ClientConn = nil
+	} else {
+		wrapper.timeInitiated = c.timeInitiated
 	}
 	select {
 	case c.pool.clients <- wrapper:

--- a/pool_test.go
+++ b/pool_test.go
@@ -141,24 +141,34 @@ func TestMaxLifeDuration(t *testing.T) {
 	}
 
 	// Let's also make sure we don't prematurely close the connection
+	count := 0
 	p, err = New(func() (*grpc.ClientConn, error) {
+		count++
 		return grpc.Dial("example.com", grpc.WithInsecure())
 	}, 1, 1, 0, time.Minute)
 	if err != nil {
 		t.Errorf("The pool returned an error: %s", err.Error())
 	}
 
-	c, err = p.Get(context.Background())
-	if err != nil {
-		t.Errorf("Get returned an error: %s", err.Error())
+	for i := 0; i < 3; i++ {
+		c, err = p.Get(context.Background())
+		if err != nil {
+			t.Errorf("Get returned an error: %s", err.Error())
+		}
+
+		// The max life of the connection is high, so when we close
+		// the connection it shouldn't be marked as unhealthy
+		if err := c.Close(); err != nil {
+			t.Errorf("Close returned an error: %s", err.Error())
+		}
+		if c.unhealthy {
+			t.Errorf("the connection shouldn't have been marked as unhealthy")
+		}
 	}
 
-	// The max life of the connection was very low (1ns), so when we close
-	// the connection it should get marked as unhealthy
-	if err := c.Close(); err != nil {
-		t.Errorf("Close returned an error: %s", err.Error())
+	//Count should have been 1 as dial function should only have been called once
+	if count > 1 {
+		t.Errorf("Dial function has been called multiple times")
 	}
-	if c.unhealthy {
-		t.Errorf("the connection shouldn't have been marked as unhealthy")
-	}
+
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -166,7 +166,7 @@ func TestMaxLifeDuration(t *testing.T) {
 		}
 	}
 
-	//Count should have been 1 as dial function should only have been called once
+	// Count should have been 1 as dial function should only have been called once
 	if count > 1 {
 		t.Errorf("Dial function has been called multiple times")
 	}


### PR DESCRIPTION
If MaxLifeDuration is set, connection was only reused once and gets closed early as during cloning of ClienConn https://github.com/processout/grpc-go-pool/blob/08356189070e8e896f90ac772a295f18718d0de0/pool.go#L205, timeInitiated was never copied, hence the following condition 
 ```
if maxDuration > 0 && c.timeInitiated.Add(maxDuration).Before(time.Now()) {
 		c.Unhealthy()
 	}
```
gets true. 

Fix is to copy the timeInitiated from the original object to the clone.

I have also extended Unit test to catch it.