### PR TITLE
fix closing connections

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -96,7 +96,6 @@ func (p *Pool) getClients() chan ClientConn {
 
 // Close empties the pool calling Close on all its clients.
 // You can call Close while there are outstanding clients.
-// It waits for all clients to be returned (Close).
 // The pool channel is then closed, and Get will not be allowed anymore
 func (p *Pool) Close() {
 	p.mu.Lock()
@@ -109,8 +108,7 @@ func (p *Pool) Close() {
 	}
 
 	close(clients)
-	for i := 0; i < p.Capacity(); i++ {
-		client := <-clients
+	for client := range clients {
 		if client.ClientConn == nil {
 			continue
 		}

--- a/pool.go
+++ b/pool.go
@@ -97,14 +97,14 @@ func (p *Pool) getClients() chan ClientConn {
 // Close empties the pool calling Close on all its clients.
 // You can call Close while there are outstanding clients.
 // The pool channel is then closed, and Get will not be allowed anymore
-func (p *Pool) Close() {
+func (p *Pool) Close() error {
 	p.mu.Lock()
 	clients := p.clients
 	p.clients = nil
 	p.mu.Unlock()
 
 	if clients == nil {
-		return
+		return nil
 	}
 
 	close(clients)
@@ -112,8 +112,10 @@ func (p *Pool) Close() {
 		if client.ClientConn == nil {
 			continue
 		}
-		client.ClientConn.Close()
+		return client.ClientConn.Close()
 	}
+
+	return nil
 }
 
 // IsClosed returns true if the client pool is closed.

--- a/pool.go
+++ b/pool.go
@@ -19,8 +19,6 @@ var (
 	ErrAlreadyClosed = errors.New("grpc pool: the connection was already closed")
 	// ErrFullPool is the error when the pool is already full
 	ErrFullPool = errors.New("grpc pool: closing a ClientConn into a full pool")
-	// ErrConnectionLeaked is the error when connections are not properly closed on pool shutdown
-	ErrConnectionLeaked = errors.New("grpc pool: connection leaked on pool closing")
 )
 
 // Factory is a function type creating a grpc client
@@ -99,16 +97,14 @@ func (p *Pool) getClients() chan ClientConn {
 // Close empties the pool calling Close on all its clients.
 // You can call Close while there are outstanding clients.
 // The pool channel is then closed, and Get will not be allowed anymore
-func (p *Pool) Close(wait time.Duration) error {
-	cap := p.Capacity()
-
+func (p *Pool) Close() {
 	p.mu.Lock()
 	clients := p.clients
 	p.clients = nil
 	p.mu.Unlock()
 
 	if clients == nil {
-		return nil
+		return
 	}
 
 	close(clients)
@@ -116,9 +112,8 @@ func (p *Pool) Close(wait time.Duration) error {
 		if client.ClientConn == nil {
 			continue
 		}
+		client.ClientConn.Close()
 	}
-
-	return nil
 }
 
 // IsClosed returns true if the client pool is closed.

--- a/pool.go
+++ b/pool.go
@@ -98,7 +98,8 @@ func (p *Pool) getClients() chan ClientConn {
 
 // Close empties the pool calling Close on all its clients.
 // You can call Close while there are outstanding clients.
-// It waits for `duration` time for all clients to be returned and close them.
+// It waits for `wait` duration for all clients to be returned and close them.
+// Otherwise error will be returned if not all connections can be collected and properly closed.
 // The pool channel is then closed, and Get will not be allowed anymore
 func (p *Pool) Close(wait time.Duration) error {
 	cap := p.Capacity()

--- a/pool.go
+++ b/pool.go
@@ -97,14 +97,14 @@ func (p *Pool) getClients() chan ClientConn {
 // Close empties the pool calling Close on all its clients.
 // You can call Close while there are outstanding clients.
 // The pool channel is then closed, and Get will not be allowed anymore
-func (p *Pool) Close() error {
+func (p *Pool) Close() {
 	p.mu.Lock()
 	clients := p.clients
 	p.clients = nil
 	p.mu.Unlock()
 
 	if clients == nil {
-		return nil
+		return
 	}
 
 	close(clients)
@@ -112,10 +112,8 @@ func (p *Pool) Close() error {
 		if client.ClientConn == nil {
 			continue
 		}
-		return client.ClientConn.Close()
+		client.ClientConn.Close()
 	}
-
-	return nil
 }
 
 // IsClosed returns true if the client pool is closed.

--- a/pool.go
+++ b/pool.go
@@ -19,6 +19,8 @@ var (
 	ErrAlreadyClosed = errors.New("grpc pool: the connection was already closed")
 	// ErrFullPool is the error when the pool is already full
 	ErrFullPool = errors.New("grpc pool: closing a ClientConn into a full pool")
+	// ErrConnectionLeaked is the error when connections are not properly closed on pool shutdown
+	ErrConnectionLeaked = errors.New("grpc pool: connection leaked on pool closing")
 )
 
 // Factory is a function type creating a grpc client
@@ -96,26 +98,35 @@ func (p *Pool) getClients() chan ClientConn {
 
 // Close empties the pool calling Close on all its clients.
 // You can call Close while there are outstanding clients.
-// It waits for all clients to be returned (Close).
+// It waits for `duration` time for all clients to be returned and close them.
 // The pool channel is then closed, and Get will not be allowed anymore
-func (p *Pool) Close() {
+func (p *Pool) Close(wait time.Duration) error {
+	cap := p.Capacity()
+
 	p.mu.Lock()
 	clients := p.clients
 	p.clients = nil
 	p.mu.Unlock()
 
 	if clients == nil {
-		return
+		return nil
 	}
 
-	close(clients)
-	for i := 0; i < p.Capacity(); i++ {
-		client := <-clients
-		if client.ClientConn == nil {
-			continue
+	defer close(clients)
+	deadline := time.Tick(wait)
+	for i := 0; i < cap; i++ {
+		select {
+		case client := <-clients:
+			if client.ClientConn == nil {
+				continue
+			}
+			client.ClientConn.Close()
+		case <-deadline:
+			return ErrConnectionLeaked
 		}
-		client.ClientConn.Close()
 	}
+
+	return nil
 }
 
 // IsClosed returns true if the client pool is closed.

--- a/pool_test.go
+++ b/pool_test.go
@@ -196,6 +196,6 @@ func TestPoolClose(t *testing.T) {
 	p.Close()
 
 	if cc.GetState() != connectivity.Shutdown {
-		t.Errorf("Returned connection was not closed")
+		t.Errorf("Returned connection was not closed, underlying connection is not in shutdown state")
 	}
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 )
 
 func TestNew(t *testing.T) {
@@ -171,4 +172,30 @@ func TestMaxLifeDuration(t *testing.T) {
 		t.Errorf("Dial function has been called multiple times")
 	}
 
+}
+
+func TestPoolClose(t *testing.T) {
+	p, err := New(func() (*grpc.ClientConn, error) {
+		return grpc.Dial("example.com", grpc.WithInsecure())
+	}, 1, 1, 0)
+	if err != nil {
+		t.Errorf("The pool returned an error: %s", err.Error())
+	}
+
+	c, err := p.Get(context.Background())
+	if err != nil {
+		t.Errorf("Get returned an error: %s", err.Error())
+	}
+
+	cc := c.ClientConn
+	if err := c.Close(); err != nil {
+		t.Errorf("Close returned an error: %s", err.Error())
+	}
+
+	// Close pool should close all underlying gRPC client connections
+	p.Close()
+
+	if cc.GetState() != connectivity.Shutdown {
+		t.Errorf("Returned connection was not closed")
+	}
 }


### PR DESCRIPTION
Few issues with closing pool.
- Capacity is not properly set, because we closed the pool already.
- There are no proper way of actually waiting for collecting all connections; so at best we can wait for x seconds and bail out.