### PR TITLE
add context supported factory method

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -52,7 +52,7 @@ type ClientConn struct {
 // clients could not be created
 func New(factory Factory, init, capacity int, idleTimeout time.Duration,
 	maxLifeDuration ...time.Duration) (*Pool, error) {
-	return NewWithContext(context.TODO(), func(ctx context.Context) (*grpc.ClientConn, error) { return factory() },
+	return NewWithContext(context.Background(), func(ctx context.Context) (*grpc.ClientConn, error) { return factory() },
 		init, capacity, idleTimeout, maxLifeDuration...)
 }
 

--- a/pool_test.go
+++ b/pool_test.go
@@ -219,7 +219,7 @@ func TestContextCancelation(t *testing.T) {
 		t.Errorf("Returned error was not context.Canceled, but the context did cancel before the invocation")
 	}
 }
-func TestContextTimout(t *testing.T) {
+func TestContextTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Microsecond)
 	defer cancel()
 
@@ -240,7 +240,7 @@ func TestContextTimout(t *testing.T) {
 	}
 }
 
-func TestGetContextTimout(t *testing.T) {
+func TestGetContextTimeout(t *testing.T) {
 	p, err := New(func() (*grpc.ClientConn, error) {
 		return grpc.Dial("example.com", grpc.WithInsecure())
 	}, 1, 1, 0)
@@ -263,7 +263,7 @@ func TestGetContextTimout(t *testing.T) {
 	}
 }
 
-func TestGetContextFactoryTimout(t *testing.T) {
+func TestGetContextFactoryTimeout(t *testing.T) {
 	p, err := NewWithContext(context.TODO(), func(ctx context.Context) (*grpc.ClientConn, error) {
 		select {
 		case <-ctx.Done():

--- a/pool_test.go
+++ b/pool_test.go
@@ -200,7 +200,7 @@ func TestPoolClose(t *testing.T) {
 	}
 }
 
-func TestContextCancellation(t *testing.T) {
+func TestContextCancelation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	cancel()
 

--- a/pool_test.go
+++ b/pool_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	p, err := New(func() (*grpc.ClientConn, error) {
+	p, err := New(func(context.Context) (*grpc.ClientConn, error) {
 		return grpc.Dial("example.com", grpc.WithInsecure())
 	}, 1, 3, 0)
 	if err != nil {
@@ -94,7 +94,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestTimeout(t *testing.T) {
-	p, err := New(func() (*grpc.ClientConn, error) {
+	p, err := New(func(context.Context) (*grpc.ClientConn, error) {
 		return grpc.Dial("example.com", grpc.WithInsecure())
 	}, 1, 1, 0)
 	if err != nil {
@@ -120,7 +120,7 @@ func TestTimeout(t *testing.T) {
 }
 
 func TestMaxLifeDuration(t *testing.T) {
-	p, err := New(func() (*grpc.ClientConn, error) {
+	p, err := New(func(context.Context) (*grpc.ClientConn, error) {
 		return grpc.Dial("example.com", grpc.WithInsecure())
 	}, 1, 1, 0, 1)
 	if err != nil {
@@ -143,7 +143,7 @@ func TestMaxLifeDuration(t *testing.T) {
 
 	// Let's also make sure we don't prematurely close the connection
 	count := 0
-	p, err = New(func() (*grpc.ClientConn, error) {
+	p, err = New(func(context.Context) (*grpc.ClientConn, error) {
 		count++
 		return grpc.Dial("example.com", grpc.WithInsecure())
 	}, 1, 1, 0, time.Minute)
@@ -175,7 +175,7 @@ func TestMaxLifeDuration(t *testing.T) {
 }
 
 func TestPoolClose(t *testing.T) {
-	p, err := New(func() (*grpc.ClientConn, error) {
+	p, err := New(func(context.Context) (*grpc.ClientConn, error) {
 		return grpc.Dial("example.com", grpc.WithInsecure())
 	}, 1, 1, 0)
 	if err != nil {

--- a/pool_test.go
+++ b/pool_test.go
@@ -201,7 +201,7 @@ func TestPoolClose(t *testing.T) {
 }
 
 func TestContextCancelation(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
 	_, err := NewWithContext(ctx, func(ctx context.Context) (*grpc.ClientConn, error) {
@@ -220,7 +220,7 @@ func TestContextCancelation(t *testing.T) {
 	}
 }
 func TestContextTimeout(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Microsecond)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Microsecond)
 	defer cancel()
 
 	_, err := NewWithContext(ctx, func(ctx context.Context) (*grpc.ClientConn, error) {
@@ -250,9 +250,9 @@ func TestGetContextTimeout(t *testing.T) {
 	}
 
 	// keep busy the available conn
-	_, _ = p.Get(context.TODO())
+	_, _ = p.Get(context.Background())
 
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Microsecond)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Microsecond)
 	defer cancel()
 
 	// wait for the deadline to pass
@@ -264,7 +264,7 @@ func TestGetContextTimeout(t *testing.T) {
 }
 
 func TestGetContextFactoryTimeout(t *testing.T) {
-	p, err := NewWithContext(context.TODO(), func(ctx context.Context) (*grpc.ClientConn, error) {
+	p, err := NewWithContext(context.Background(), func(ctx context.Context) (*grpc.ClientConn, error) {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -281,14 +281,14 @@ func TestGetContextFactoryTimeout(t *testing.T) {
 	}
 
 	// mark as unhealty the available conn
-	c, err := p.Get(context.TODO())
+	c, err := p.Get(context.Background())
 	if err != nil {
 		t.Errorf("Get returned an error: %s", err.Error())
 	}
 	c.Unhealthy()
 	c.Close()
 
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Microsecond)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Microsecond)
 	defer cancel()
 
 	_, err = p.Get(ctx)


### PR DESCRIPTION
I need to use a context in the factory function to create a new gRPC connection with some parameters like TLS which are found be in the context. So, I added context support to the factory function and sharing with you to merge if you want.